### PR TITLE
Allow running autobahn tests from MacOS hosts

### DIFF
--- a/support/autobahn/config.json
+++ b/support/autobahn/config.json
@@ -1,6 +1,6 @@
 {
 	"outdir": "/ab/reports/",
-	"servers": [{"agent": "websocket.zig", "url": "ws://127.0.0.1:9223"}],
+	"servers": [{"agent": "websocket.zig", "url": "ws://host.docker.internal:9223"}],
 	"cases": ["*"],
 	"exclude-cases": [],
 	"exclude-agent-cases": {}


### PR DESCRIPTION
127.0.0.1 does not resolve from the docker image crossbario/autobahn-testsuite to the host when running on macOs.

According to https://docs.docker.com/desktop/networking/#per-container-ip-addressing-is-not-possible the hostname `host.docker.internal` will be resolved to the locahost network ip. With this change I was able to run `make ab`