### PR TITLE
add afterInit hook to Handler

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,9 @@ const Handler = struct {
         };
     }
 
+    // optional hook that, if present, will be called after initialization is complete
+    pub fn afterInit(self: *Handler) !void {}
+
     pub fn handle(self: *Handler, message: Message) !void {
         const data = message.data;
         try self.client.write(data); // echo the message back

--- a/src/client.zig
+++ b/src/client.zig
@@ -148,6 +148,10 @@ fn handleLoop(comptime H: type, allocator: Allocator, context: anytype, stream: 
 		state.fragment.deinit();
 	}
 
+	if (comptime std.meta.trait.hasFn("afterInit")(H)) {
+		try handler.afterInit();
+	}
+
 	while (true) {
 		buf.next();
 		const result = readFrame(stream, state) catch |err| {


### PR DESCRIPTION
I needed this for my use case because I wanted to send a message to a client immediately after it connects, but I found that sending it inside the `init` hook would cause the connection to fail somehow.