### PR TITLE
zig package manager support

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,11 @@
+.{
+    .name = "websocket.zig",
+    .version = "0.1.0",
+    .dependencies = .{},
+    .path = .{
+        "readme.md",
+        "build.zig",
+        "build.zig.zon",
+        "src",
+    },
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "websocket.zig",
+    .name = "websocket-zig",
     .version = "0.1.0",
     .dependencies = .{},
     .path = .{


### PR DESCRIPTION
Adds a simple`build.zig.zon` file that enables zig package manager support thereby avoiding the need for git submodules