### PR TITLE
update to latest zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,22 +1,17 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) !void {
-	const target = b.standardTargetOptions(.{});
-	const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
-	_ = b.addModule("websocket", .{
-		.root_source_file = .{ .path = "src/websocket.zig" },
-	});
+    _ = b.addModule("websocket", .{
+        .root_source_file = .{ .path = "src/websocket.zig" },
+    });
 
-	const lib_test = b.addTest(.{
-		.root_source_file = .{ .path = "src/websocket.zig" },
-		.target = target,
-		.optimize = optimize,
-		.test_runner = "test_runner.zig",
-	});
-	const run_test = b.addRunArtifact(lib_test);
-	run_test.has_side_effects = true;
+    const lib_test = b.addTest(.{ .root_source_file = .{ .path = "src/websocket.zig" }, .target = target, .optimize = optimize, .test_runner = .{ .path = "test_runner.zig" } });
+    const run_test = b.addRunArtifact(lib_test);
+    run_test.has_side_effects = true;
 
-	const test_step = b.step("test", "Run tests");
-	test_step.dependOn(&run_test.step);
+    const test_step = b.step("test", "Run tests");
+    test_step.dependOn(&run_test.step);
 }


### PR DESCRIPTION
The latest zig now takes a `LazyPath` for the test runner property instead of the hardcoded "string".