### PR TITLE
fix proto Reader init in testing helper

### DIFF
--- a/src/testing.zig
+++ b/src/testing.zig
@@ -39,7 +39,7 @@ pub const Testing = struct {
         }) catch unreachable;
 
         const reader_buf = aa.alloc(u8, 1024) catch unreachable;
-        const reader = ws.proto.Reader.init(reader_buf, buffer_provider);
+        const reader = ws.proto.Reader.init(reader_buf, buffer_provider, null);
 
         return .{
             .closed = false,


### PR DESCRIPTION
default to no compression, since the testing helper is focused on message handling at the application level.