### PR TITLE
Use string literal for zon name

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-	.name = .websocket,
+	.name = ".websocket",
 	.version = "0.1.0",
 	.dependencies = .{},
 	.fingerprint = 0x42ce80b97512f264,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-	.name = ".websocket",
+	.name = "websocket",
 	.version = "0.1.0",
 	.dependencies = .{},
 	.fingerprint = 0x42ce80b97512f264,


### PR DESCRIPTION
On Zig `0.14.0-dev`, using the package manager returns an error:

```
zig fetch --save git+https://github.com/karlseguin/websocket.zig
/Users/logain/.cache/zig/tmp/7f16931c7900cdc2build.zig.zon:2:11: error: expected string literal
 .name = .websocket,
          ^~~~~~~~~
```

Changing it to a string literal fixes it:

```
zig fetch --save git+https://github.com/AlvarezAriel/websocket.zig
info: resolved to commit b866a058faa6bf61a00e2b56ff2b4ca844af3037
```


