### PR TITLE
Fix: Client: only send message frames compressed

### DIFF
--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -370,7 +370,7 @@ pub const Client = struct {
         var payload = data;
         var compressed = false;
         if (self._compression) |c| {
-            if (data.len >= c.write_treshold) {
+            if (data.len >= c.write_treshold and (op_code == .binary or op_code == .text)) {
                 compressed = true;
 
                 var writer = &c.writer;


### PR DESCRIPTION
I tried interfacing with a service that uses python-websockets and it turns out that it rejects pings that are compressed.

This change fixes that as well as the Autobahn "UNCLEAN" mentioned in #73 for 12.1.1.
Gonna let the whole Autobahn test run now, but I am confident this was the problem.