### PR TITLE
Fix client regression: Calling client.close() on a TLS connection while readLoop is running results in a crash

### DIFF
--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -406,6 +406,8 @@ pub const Stream = struct {
 
     pub fn close(self: *Stream) void {
         if (self.tls_client) |tls_client| {
+            // Shutdown the socket first, so readLoop() can exit, before tls_client's buffers are freed
+            std.posix.shutdown(self.stream.handle, .both) catch {};
             tls_client.deinit();
         }
 


### PR DESCRIPTION
Calling `client.close()` on a TLS client connection while the `readLoop()` is running causes a segfault or `std.posix.readv()` returns with `errno = EFAULT` which is marked `unreachable`. 

This PR calls `std.posix.shutdown()` on the socket, before cleaning up the TLSClient instance. This gracefully exits from the read loop, before the TLSClient buffers are freed.

Reproducible example:
```zig
const std = @import("std");
const websocket = @import("websocket");

pub fn main() !void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    const allocator = gpa.allocator();
    var client = try websocket.Client.init(allocator, .{
        .port = 443,
        .host = "foo.bar",
        .tls = true,
    });
    defer client.deinit();
    const request_path = "/";
    try client.handshake(request_path, .{
        .timeout_ms = 1000,
        .headers = "Host: foo.bar:443",
    });
    var handler: struct {
        pub fn serverMessage(self: *@This(), data: []u8) !void {
            _ = self;
            std.debug.print("got msg={s}\n", .{data});
        }
    } = .{};
    const thread = try client.readLoopInNewThread(&handler);
    std.debug.print("waiting...\n", .{});
    std.Thread.sleep(3 * std.time.ns_per_s);
    std.debug.print("done\n", .{});
    try client.close(.{});
    thread.join();
}
```