### PR TITLE
fix: replace ambiguous '{}' with '{f}' in log.info for std.net.Address

### DIFF
--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -210,7 +210,7 @@ pub fn Server(comptime H: type) type {
                 defer w.deinit();
 
                 const thrd = try std.Thread.spawn(.{}, Blocking(H).run, .{ &w, socket, ctx });
-                log.info("starting blocking worker to listen on {}", .{address});
+                log.info("starting blocking worker to listen on {f}", .{address});
 
                 // incase listenInNewThread was used and is waiting for us to start
                 self._cond.signal();


### PR DESCRIPTION
replace ambiguous '{}' with '{f}' in log.info for std.net.Address

this fixes a compile error I was facing when building for windows

ref: https://ziglang.org/download/0.15.1/release-notes.html?utm_source=chatgpt.com#f-Required-to-Call-format-Methods