### PR TITLE
Annotate return type of Handler.close() method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,7 +169,7 @@ clientMessage(h: *Handler, allocator: Allocator, data: []u8, tpe: ws.MessageText
 If `clientMessage` returns an error, the connection is closed. You can also call `conn.close()` within the method.
 
 ### close
-If your handler defines a `close(handler: *Handler)` method, the method is called whenever the connection is being closed. Guaranteed to be called exactly once, so it is safe to deinitialize the `handler` at this point. This is called no mater the reason for the closure (on shutdown, if the client closed the connection, if your code close the connection, ...)
+If your handler defines a `close(handler: *Handler) void` method, the method is called whenever the connection is being closed. Guaranteed to be called exactly once, so it is safe to deinitialize the `handler` at this point. This is called no matter the reason for the closure (on shutdown, if the client closed the connection, if your code close the connection, ...)
 
 The socket may or may not still be alive.
 


### PR DESCRIPTION
I wasn't sure about what return type the `close()` method in my `Handler` type should have and assumed it to be `!void` at first. I got an unintuitive compiler error 16 indirections deep in the stack trace. It worked after setting it to `void` but idk if it's intended that way.
Either way I would like to have it mentioned in the README.
Thank you!