### PR TITLE
quick fix for https://github.com/karlseguin/websocket.zig/issues/97

### DIFF
--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -441,7 +441,10 @@ pub const Stream = struct {
         if (self.tls_client) |tls_client| {
             var w: std.Io.Writer = .fixed(buf);
             while (true) {
-                const n = try tls_client.client.reader.stream(&w, .limited(buf.len));
+                const n = tls_client.client.reader.stream(&w, .limited(buf.len)) catch |e| {
+                    if (tls_client.stream_reader.getError()) |se| return se;
+                    return e;
+                };
                 if (n != 0) {
                     return n;
                 }


### PR DESCRIPTION
kinda kluge propagates error.WouldBlock into Client.read for empty TLS buffer leading to consistent behavior. Not tested for all scenarios.
