### PR TITLE
use @splat() in place of already removed ** operator

### DIFF
--- a/src/websocket.zig
+++ b/src/websocket.zig
@@ -58,7 +58,7 @@ test "frameText" {
     }
 
     {
-        const msg = "A" ** 130;
+        const msg = &@as([130]u8, @splat('A'));
         const framed = frameText(msg);
 
         try t.expectEqual(134, framed.len);
@@ -87,8 +87,8 @@ test "frameBin" {
     }
 
     {
-        const msg = "A" ** 130;
-        const framed = frameBin(msg);
+        const msg = @as([130]u8, @splat('A'));
+        const framed = frameBin(&msg);
 
         try t.expectEqual(134, framed.len);
 

--- a/test_runner.zig
+++ b/test_runner.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 
 const Allocator = std.mem.Allocator;
 
-const BORDER = "=" ** 80;
+const BORDER: [80]u8 = @splat('=');
 
 pub const std_options = std.Options{ .log_scope_levels = &[_]std.log.ScopeLevel{
     .{ .scope = .websocket, .level = .warn },


### PR DESCRIPTION
I will do a second PR to http.zig with correct subpath when this is merged, note that this also compiles fine in zig16