### PR TITLE
client: poll for read readiness instead of SO_RCVTIMEO

### DIFF
--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -448,15 +448,22 @@ pub const Stream = struct {
         // SO_RCVTIMEO produces on timeout) as a programmer bug and panics in
         // debug builds. Polling lets a timeout surface as error.WouldBlock (which
         // read() turns into "no message") without ever issuing a read that could
-        // EAGAIN. The caller drains its buffer before reaching here, so polling
-        // only gates an actual socket read.
-        if (self.read_timeout_ms > 0) {
+        // EAGAIN.
+        //
+        // Skip the poll when the TLS client already has decrypted plaintext
+        // buffered: a previous read can decrypt more than the caller consumed, so
+        // the socket can be empty (poll would time out) even though data is
+        // available in-process, which would starve it.
+        const tls_buffered = if (self.tls_client) |tls_client| tls_client.client.reader.bufferedLen() else 0;
+        if (self.read_timeout_ms > 0 and tls_buffered == 0) {
             var pfd = [_]std.posix.pollfd{.{
                 .fd = self.stream.socket.handle,
                 .events = std.posix.POLL.IN,
                 .revents = 0,
             }};
-            const ready = std.posix.poll(&pfd, @intCast(self.read_timeout_ms)) catch 0;
+            // A poll failure is a real read failure, not "no data": surface it
+            // (mapped into this read path's error set) rather than swallowing it.
+            const ready = std.posix.poll(&pfd, @intCast(self.read_timeout_ms)) catch return error.ReadFailed;
             if (ready == 0) return error.WouldBlock;
         }
         if (self.tls_client) |tls_client| {

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -286,7 +286,7 @@ pub const Client = struct {
         return self.stream.writeTimeout(ms);
     }
 
-    pub fn readTimeout(self: *const Client, ms: u32) !void {
+    pub fn readTimeout(self: *Client, ms: u32) !void {
         return self.stream.readTimeout(ms);
     }
 
@@ -400,6 +400,7 @@ pub const Stream = struct {
     io: Io,
     stream: Io.net.Stream,
     tls_client: ?*TLSClient = null,
+    read_timeout_ms: u32 = 0,
 
     pub fn init(io: Io, stream: Io.net.Stream, tls_client: ?*TLSClient) Stream {
         return .{
@@ -441,6 +442,23 @@ pub const Stream = struct {
     }
 
     pub fn read(self: *Stream, buf: []u8) !usize {
+        // A read timeout is implemented by polling the socket for readiness
+        // rather than SO_RCVTIMEO. On the TLS path the underlying read goes
+        // through std.crypto.tls, whose reader treats a socket EAGAIN (what
+        // SO_RCVTIMEO produces on timeout) as a programmer bug and panics in
+        // debug builds. Polling lets a timeout surface as error.WouldBlock (which
+        // read() turns into "no message") without ever issuing a read that could
+        // EAGAIN. The caller drains its buffer before reaching here, so polling
+        // only gates an actual socket read.
+        if (self.read_timeout_ms > 0) {
+            var pfd = [_]std.posix.pollfd{.{
+                .fd = self.stream.socket.handle,
+                .events = std.posix.POLL.IN,
+                .revents = 0,
+            }};
+            const ready = std.posix.poll(&pfd, @intCast(self.read_timeout_ms)) catch 0;
+            if (ready == 0) return error.WouldBlock;
+        }
         if (self.tls_client) |tls_client| {
             var w: std.Io.Writer = .fixed(buf);
             while (true) {
@@ -473,8 +491,10 @@ pub const Stream = struct {
         return self.setTimeout(posix.SO.SNDTIMEO, ms);
     }
 
-    pub fn readTimeout(self: *const Stream, ms: u32) !void {
-        return self.setTimeout(posix.SO.RCVTIMEO, ms);
+    pub fn readTimeout(self: *Stream, ms: u32) !void {
+        // Stored and applied via poll() in read(); see the note there for why this
+        // does not use SO_RCVTIMEO.
+        self.read_timeout_ms = ms;
     }
 
     fn setTimeout(self: *const Stream, opt_name: u32, ms: u32) !void {


### PR DESCRIPTION
## Problem

Setting a read timeout via `readTimeout()` (SO_RCVTIMEO) makes a timed-out read return `EAGAIN`. On a plaintext socket the client's posix wrapper maps that to `error.WouldBlock`, which `Client.read()` turns into "no message" (returns null). But on a TLS connection the read goes through `std.crypto.tls`, whose `std` reader treats `EAGAIN` as a programmer bug and `std.debug.panic`s in debug builds:

```
thread panic: programmer bug caused syscall error: AGAIN
  std/Io/Threaded.zig netReadPosix  .AGAIN => errnoBug
  std/crypto/tls/Client.zig stream
  src/client/client.zig:447 Stream.read
```

So any TLS client that uses a read timeout to poll (e.g. to check a shutdown flag) crashes the first time the peer goes quiet for longer than the timeout.

## Fix

Implement the read timeout by polling the fd for readiness in `Stream.read` instead of `SO_RCVTIMEO`. A timeout then surfaces as `error.WouldBlock` (same as the plaintext path) without ever issuing a read that can `EAGAIN`. `Client.read()` drains its buffer before reaching the socket read, so the poll only gates an actual socket read.

`readTimeout()` now stores the timeout (no longer sets SO_RCVTIMEO); `read()` polls with it. `writeTimeout` is unchanged.

Tested against a real TLS websocket server: a 1s read-timeout poll loop that previously panicked in debug now runs cleanly, and connections stay open across quiet periods.