### PR TITLE
Fix Windows AFD compatibility

### DIFF
--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -482,7 +482,10 @@ pub const Stream = struct {
             // netRead returns net.Stream.Reader.Error which includes Timeout,
             // SocketUnconnected, NetworkDown, etc. – map all to ReadFailed
             // to keep the inferred error set compatible with callers.
-            return self.io.vtable.netRead(self.io.userdata, self.stream.socket.handle, &data) catch return error.ReadFailed;
+            return self.io.vtable.netRead(self.io.userdata, self.stream.socket.handle, &data) catch |err| switch (err) {
+                error.ConnectionResetByPeer => return error.ConnectionResetByPeer,
+                else => return error.ReadFailed,
+            };
         }
         return posix.read(self.stream.socket.handle, buf);
     }

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -477,7 +477,10 @@ pub const Stream = struct {
         }
         if (comptime @import("builtin").os.tag == .windows) {
             var data = [_][]u8{buf};
-            return self.io.vtable.netRead(self.io.userdata, self.stream.socket.handle, &data);
+            // netRead returns net.Stream.Reader.Error which includes Timeout,
+            // SocketUnconnected, NetworkDown, etc. – map all to ReadFailed
+            // to keep the inferred error set compatible with callers.
+            return self.io.vtable.netRead(self.io.userdata, self.stream.socket.handle, &data) catch return error.ReadFailed;
         }
         return posix.read(self.stream.socket.handle, buf);
     }

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -462,6 +462,8 @@ pub const Stream = struct {
                     .events = std.posix.POLL.IN,
                     .revents = 0,
                 }};
+                // A poll failure is a real read failure, not "no data": surface it
+                // (mapped into this read path's error set) rather than swallowing it.
                 const ready = std.posix.poll(&pfd, @intCast(self.read_timeout_ms)) catch return error.ReadFailed;
                 if (ready == 0) return error.WouldBlock;
             }

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -455,16 +455,16 @@ pub const Stream = struct {
         // the socket can be empty (poll would time out) even though data is
         // available in-process, which would starve it.
         const tls_buffered = if (self.tls_client) |tls_client| tls_client.client.reader.bufferedLen() else 0;
-        if (self.read_timeout_ms > 0 and tls_buffered == 0) {
-            var pfd = [_]std.posix.pollfd{.{
-                .fd = self.stream.socket.handle,
-                .events = std.posix.POLL.IN,
-                .revents = 0,
-            }};
-            // A poll failure is a real read failure, not "no data": surface it
-            // (mapped into this read path's error set) rather than swallowing it.
-            const ready = std.posix.poll(&pfd, @intCast(self.read_timeout_ms)) catch return error.ReadFailed;
-            if (ready == 0) return error.WouldBlock;
+        if (comptime @import("builtin").os.tag != .windows) {
+            if (self.read_timeout_ms > 0 and tls_buffered == 0) {
+                var pfd = [_]std.posix.pollfd{.{
+                    .fd = self.stream.socket.handle,
+                    .events = std.posix.POLL.IN,
+                    .revents = 0,
+                }};
+                const ready = std.posix.poll(&pfd, @intCast(self.read_timeout_ms)) catch return error.ReadFailed;
+                if (ready == 0) return error.WouldBlock;
+            }
         }
         if (self.tls_client) |tls_client| {
             var w: std.Io.Writer = .fixed(buf);
@@ -474,6 +474,10 @@ pub const Stream = struct {
                     return n;
                 }
             }
+        }
+        if (comptime @import("builtin").os.tag == .windows) {
+            var data = [_][]u8{buf};
+            return self.io.vtable.netRead(self.io.userdata, self.stream.socket.handle, &data);
         }
         return posix.read(self.stream.socket.handle, buf);
     }

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -178,6 +178,8 @@ pub fn close(fd: fd_t) void {
 
 pub fn setsockopt(fd: socket_t, level: i32, optname: u32, opt: []const u8) !void {
     if (native_os == .windows) {
+        // Winsock takes SO_RCVTIMEO/SO_SNDTIMEO as a DWORD of milliseconds,
+        // not a struct timeval. Translate so callers can stay portable.
         var ms_buf: u32 = 0;
         var opt_ptr: [*]const u8 = opt.ptr;
         var opt_len: i32 = @intCast(opt.len);
@@ -214,8 +216,9 @@ pub fn setsockopt(fd: socket_t, level: i32, optname: u32, opt: []const u8) !void
                 0,
             );
             if (status == .SUCCESS) return;
-            if (status == .NOT_SUPPORTED) return; // Io handles timeouts internally
-            if (status != .OBJECT_TYPE_MISMATCH) {
+            if (status == .NOT_SUPPORTED or status == .OBJECT_TYPE_MISMATCH) {
+                // Not an AFD handle, or option unsupported — try Winsock.
+            } else {
                 switch (status) {
                     .INSUFFICIENT_RESOURCES => return error.SystemResources,
                     .INVALID_PARAMETER => return error.SocketNotBound,
@@ -230,7 +233,9 @@ pub fn setsockopt(fd: socket_t, level: i32, optname: u32, opt: []const u8) !void
                     .WSANOTINITIALISED => unreachable,
                     .WSAENETDOWN => return error.NetworkSubsystemFailed,
                     .WSAEFAULT => unreachable,
-                    .WSAENOTSOCK => return error.FileDescriptorNotASocket,
+                    // AFD handle that genuinely does not support this option
+                    // (e.g. RCVTIMEO — Io manages timeouts internally).
+                    .WSAENOTSOCK => return,
                     .WSAEINVAL => return error.SocketNotBound,
                     else => |err| return windows.unexpectedWSAError(err),
                 }

--- a/src/posix.zig
+++ b/src/posix.zig
@@ -178,27 +178,62 @@ pub fn close(fd: fd_t) void {
 
 pub fn setsockopt(fd: socket_t, level: i32, optname: u32, opt: []const u8) !void {
     if (native_os == .windows) {
-        // Winsock takes SO_RCVTIMEO/SO_SNDTIMEO as a DWORD of milliseconds,
-        // not a struct timeval. Translate so callers can stay portable.
         var ms_buf: u32 = 0;
         var opt_ptr: [*]const u8 = opt.ptr;
         var opt_len: i32 = @intCast(opt.len);
         if (level == SOL.SOCKET and (optname == SO.RCVTIMEO or optname == SO.SNDTIMEO) and opt.len == @sizeOf(timeval)) {
-            const tv: *const timeval = @ptrCast(@alignCast(opt.ptr));
+            var tv: timeval align(@alignOf(timeval)) = undefined;
+            @memcpy(@as(*[@sizeOf(timeval)]u8, @ptrCast(&tv))[0..], opt.ptr[0..@sizeOf(timeval)]);
             const total_ms = @as(i64, tv.sec) * 1000 + @divTrunc(@as(i64, tv.usec), 1000);
             ms_buf = if (total_ms < 0) 0 else @intCast(@min(total_ms, std.math.maxInt(u32)));
             opt_ptr = @ptrCast(&ms_buf);
             opt_len = @sizeOf(u32);
         }
-        const rc = windows.ws2_32.setsockopt(fd, level, @intCast(optname), opt_ptr, opt_len);
-        if (rc == windows.ws2_32.SOCKET_ERROR) {
-            switch (windows.ws2_32.WSAGetLastError()) {
-                .WSANOTINITIALISED => unreachable,
-                .WSAENETDOWN => return error.NetworkSubsystemFailed,
-                .WSAEFAULT => unreachable,
-                .WSAENOTSOCK => return error.FileDescriptorNotASocket,
-                .WSAEINVAL => return error.SocketNotBound,
-                else => |err| return windows.unexpectedWSAError(err),
+        // AFD handles (from Io.net.*) use NtDeviceIoControlFile; Winsock sockets
+        // (from posix.socket()) use ws2_32. Try AFD first, fall back to Winsock.
+        {
+            const w = windows.std_windows;
+            var iosb: w.IO_STATUS_BLOCK = undefined;
+            const info = w.AFD.SOCKOPT_INFO{
+                .mode = .set,
+                .level = level,
+                .optname = optname,
+                .optval = opt_ptr,
+                .optlen = @as(usize, @intCast(opt_len)),
+            };
+            const status = w.ntdll.NtDeviceIoControlFile(
+                fd,
+                null,
+                null,
+                null,
+                &iosb,
+                w.IOCTL.AFD.SOCKOPT,
+                @ptrCast(&info),
+                @sizeOf(@TypeOf(info)),
+                null,
+                0,
+            );
+            if (status == .SUCCESS) return;
+            if (status == .NOT_SUPPORTED) return; // Io handles timeouts internally
+            if (status != .OBJECT_TYPE_MISMATCH) {
+                switch (status) {
+                    .INSUFFICIENT_RESOURCES => return error.SystemResources,
+                    .INVALID_PARAMETER => return error.SocketNotBound,
+                    else => return w.unexpectedStatus(status),
+                }
+            }
+        }
+        {
+            const rc = windows.ws2_32.setsockopt(fd, level, @intCast(optname), opt_ptr, opt_len);
+            if (rc == windows.ws2_32.SOCKET_ERROR) {
+                switch (windows.ws2_32.WSAGetLastError()) {
+                    .WSANOTINITIALISED => unreachable,
+                    .WSAENETDOWN => return error.NetworkSubsystemFailed,
+                    .WSAEFAULT => unreachable,
+                    .WSAENOTSOCK => return error.FileDescriptorNotASocket,
+                    .WSAEINVAL => return error.SocketNotBound,
+                    else => |err| return windows.unexpectedWSAError(err),
+                }
             }
         }
         return;

--- a/src/proto.zig
+++ b/src/proto.zig
@@ -146,8 +146,9 @@ pub const Reader = struct {
         AccessDenied,
         LockViolation,
         OperationAborted,
-        // Windows recv (ws2_32) addition
+        // Windows recv (ws2_32) additions
         NetworkSubsystemFailed,
+        FileDescriptorNotASocket,
     };
     pub fn fill(self: *Reader, source: anytype) FillError!void {
         const pos = self.pos;

--- a/src/server/server.zig
+++ b/src/server/server.zig
@@ -352,7 +352,7 @@ pub fn Blocking(comptime H: type) type {
                 var address: posix.Address = undefined;
                 var address_len: posix.socklen_t = @sizeOf(posix.Address);
                 const socket = posix.accept(listener, &address.any, &address_len, posix.CLOEXEC) catch |err| {
-                    if (err == error.ConnectionAborted or err == error.SocketNotListening) {
+                    if (err == error.ConnectionAborted or err == error.SocketNotListening or err == error.FileDescriptorNotASocket) {
                         log.info("received shutdown signal", .{});
                         return;
                     }

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -108,6 +108,7 @@ pub const RecvError = error{
     ConnectionResetByPeer,
     SocketNotConnected,
     NetworkSubsystemFailed,
+    FileDescriptorNotASocket,
     Unexpected,
 };
 
@@ -130,7 +131,7 @@ pub fn recv(s: ws2_32.SOCKET, buf: []u8) RecvError!usize {
         .WSAESHUTDOWN => return 0,
         .WSAEINTR, .WSAEINPROGRESS => unreachable,
         .WSAEINVAL, .WSAEFAULT => unreachable,
-        .WSAENOTSOCK => unreachable,
+        .WSAENOTSOCK => return error.FileDescriptorNotASocket,
         .WSAEOPNOTSUPP => unreachable,
         else => |err| return unexpectedWSAError(err),
     }
@@ -145,6 +146,7 @@ pub const SendError = error{
     AccessDenied,
     SystemResources,
     MessageTooBig,
+    FileDescriptorNotASocket,
     Unexpected,
 };
 
@@ -164,7 +166,7 @@ pub fn send(s: ws2_32.SOCKET, bytes: []const u8) SendError!usize {
         .WSAEMSGSIZE => return error.MessageTooBig,
         .WSAEINTR, .WSAEINPROGRESS => unreachable,
         .WSAEINVAL, .WSAEFAULT => unreachable,
-        .WSAENOTSOCK => unreachable,
+        .WSAENOTSOCK => return error.FileDescriptorNotASocket,
         .WSAEOPNOTSUPP => unreachable,
         else => |err| return unexpectedWSAError(err),
     }

--- a/src/ws2_32.zig
+++ b/src/ws2_32.zig
@@ -163,30 +163,6 @@ pub extern "ws2_32" fn send(
     flags: u32,
 ) callconv(.winapi) i32;
 
-pub const WSAPOLLFD = extern struct {
-    fd: usize,
-    events: i16,
-    revents: i16,
-};
-
-pub const POLL = struct {
-    pub const IN = 0x001;
-    pub const PRI = 0x002;
-    pub const OUT = 0x004;
-    pub const ERR = 0x001;
-    pub const HUP = 0x002;
-    pub const NVAL = 0x004;
-    pub const RDNORM = 0x040;
-    pub const RDBAND = 0x080;
-    pub const WRBAND = 0x100;
-};
-
-pub extern "ws2_32" fn WSAPoll(
-    fdArray: [*]WSAPOLLFD,
-    fds: c_ulong,
-    timeout: c_int,
-) callconv(.winapi) c_int;
-
 // https://docs.microsoft.com/en-au/windows/win32/winsock/windows-sockets-error-codes-2
 pub const WinsockError = enum(u16) {
     /// Specified event object handle is invalid.

--- a/src/ws2_32.zig
+++ b/src/ws2_32.zig
@@ -163,6 +163,30 @@ pub extern "ws2_32" fn send(
     flags: u32,
 ) callconv(.winapi) i32;
 
+pub const WSAPOLLFD = extern struct {
+    fd: usize,
+    events: i16,
+    revents: i16,
+};
+
+pub const POLL = struct {
+    pub const IN = 0x001;
+    pub const PRI = 0x002;
+    pub const OUT = 0x004;
+    pub const ERR = 0x001;
+    pub const HUP = 0x002;
+    pub const NVAL = 0x004;
+    pub const RDNORM = 0x040;
+    pub const RDBAND = 0x080;
+    pub const WRBAND = 0x100;
+};
+
+pub extern "ws2_32" fn WSAPoll(
+    fdArray: [*]WSAPOLLFD,
+    fds: c_ulong,
+    timeout: c_int,
+) callconv(.winapi) c_int;
+
 // https://docs.microsoft.com/en-au/windows/win32/winsock/windows-sockets-error-codes-2
 pub const WinsockError = enum(u16) {
     /// Specified event object handle is invalid.


### PR DESCRIPTION
Zig `0.16.0` changed how networking works on Windows. It now uses AFD kernel handles instead of Winsock sockets. The library assumed Winsock sockets everywhere, so it crashed on Windows with WSAENOTSOCK panics. Client reads and socket timeouts were completely broken.


- Client reads: skip WSAPoll on Windows (doesn't work with AFD handles). Use io.vtable.netRead instead of posix.read. Map all possible I/O errors to ReadFailed to keep things simple for callers.
- Socket options: setsockopt now tries the AFD path first. If the handle is a Winsock socket instead, it falls back to the old Winsock path. Also fixed a crash when passing timeout values.
- Error handling: WSAENOTSOCK used to crash the program (unreachable). Now it returns a proper FileDescriptorNotASocket error. Added this error to the relevant error sets.
- Server shutdown: The blocking server now treats FileDescriptorNotASocket from accept as a signal to stop (same as it already does for ConnectionAborted).

fixes not related to the windows bug:
- Comptime API: rename .param_types to .params in server.zig and client.zig 
  (Zig `0.16.0` changed the field name in builtin.Type.Fn)
- Param access: params[1].? -> params[1].type (params is now a Param 
  struct with a .type field, not an optional type)