### PR TITLE
client: fix TLS read timeout when ciphertext is buffered but undecrypted (#106)

### DIFF
--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -449,7 +449,7 @@ pub const Stream = struct {
                 // >0 only once that buffer holds plaintext. A single stream()
                 // will often (typically?) returns 0 without yielding a plaintext
                 // message. We have to loop until we get a visible message..
-                if (tls_client.client.reader.bufferedLen() == 0 and !try self.pollReadable()) {
+                if (tls_client.client.reader.bufferedLen() == 0 and tls_client.client.input.bufferedLen() == 0 and !try self.pollReadable()) {
                     return error.WouldBlock;
                 }
                 const n = try tls_client.client.reader.stream(&w, .limited(buf.len));


### PR DESCRIPTION
## Summary

The 2026-07-04 "Improve Client read over TLS" change (`7afc284`, referenced by #106) fixed
the common case, but a TLS client `handshake()` against **api.openai.com (Cloudflare)** still
times out deterministically. This adds the missing half of the buffered-data check — one line.

## Root cause

`Stream.read` concludes "nothing to read" (`error.WouldBlock`) when the decrypted-plaintext
buffer is empty and the raw socket has nothing new to poll:

```zig
if (tls_client.client.reader.bufferedLen() == 0 and !try self.pollReadable()) {
    return error.WouldBlock;
}
```

But `std.crypto.tls.Client` has **two** buffers: `reader` holds decrypted *plaintext*, and
`input` holds encrypted *ciphertext* already pulled off the socket but not yet decrypted. When
a peer delivers the handshake response + first records in a single burst (Cloudflare does
this), the socket drains into `input`, `poll()` then reports "nothing readable", and
`reader.bufferedLen()` is still `0` because `stream()` hasn't been called to decrypt yet. The
guard fires `WouldBlock` even though a complete plaintext message is one `stream()` call away
→ `handshake()` surfaces `error.Timeout`.

Instrumented on a real connect: **1293 encrypted bytes buffered in `input` while
`pollReadable()` returned false.**

## Fix

Only give up when *both* buffers are empty:

```diff
-                if (tls_client.client.reader.bufferedLen() == 0 and !try self.pollReadable()) {
+                if (tls_client.client.reader.bufferedLen() == 0 and tls_client.client.input.bufferedLen() == 0 and !try self.pollReadable()) {
```

If `input` still holds ciphertext, fall through to `stream()`, which decrypts it into a
plaintext message.

## Reproduction

- Zig `0.17.0-dev.1267+300116b02`; websocket.zig `master` `7afc284` (identical guard on `dev`
  `2283d22`).
- Client `handshake("/v1/realtime", .{ .timeout_ms = 10_000, ... })` to
  `wss://api.openai.com/v1/realtime` (any key works for the repro — the server returns `101`
  before authenticating, then sends the error in-band).
- **Before:** `error.Timeout` inside `handshake()`, 3/3 runs.
- **After:** `101` accepted; the first server text frame (the in-band `invalid_api_key` error
  event) and the close frame are read normally.
- `wss://echo.websocket.org` does **not** trigger it — it doesn't burst the handshake reply and
  first records together — which is likely why the earlier fix looked complete.

Verified end-to-end against a live streaming transcription session, not just the handshake.

Both `master` and `dev` carry the identical guard, so the fix applies to both.

Closes #106.
