### PR TITLE
client: bounded connect and TLS handshake timeout

### DIFF
--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -35,6 +35,162 @@ fn ReadLoopHandler(comptime T: type) type {
     }
 }
 
+// Resolve `host` and connect to `port` with the TCP connect bounded by
+// `timeout_ms`. The Threaded Io panics when asked for a connect timeout, so the
+// connect is driven manually: a non-blocking connect gated by poll(). The
+// returned stream's socket is left in blocking mode for the handshake and read
+// paths.
+//
+// `timeout_ms == 0` disables the bound, matching `readTimeout(0)`. Windows has
+// no usable poll()-gated connect — WSAPoll cannot report a failed non-blocking
+// connect, and std.posix.pollfd does not exist there — so it falls back to the
+// unbounded std connect.
+fn connectTimeout(io: Io, host: []const u8, port: u16, timeout_ms: u32) !Io.net.Stream {
+    const host_name = try Io.net.HostName.init(host);
+
+    if (comptime @import("builtin").os.tag == .windows) {
+        return host_name.connect(io, port, .{ .mode = .stream });
+    } else {
+        if (timeout_ms == 0) {
+            return host_name.connect(io, port, .{ .mode = .stream });
+        }
+        return connectTimeoutPosix(io, host_name, port, timeout_ms);
+    }
+}
+
+fn connectTimeoutPosix(io: Io, host_name: Io.net.HostName, port: u16, timeout_ms: u32) !Io.net.Stream {
+    var lookup_buf: [32]Io.net.HostName.LookupResult = undefined;
+    var lookup_queue = Io.Queue(Io.net.HostName.LookupResult).init(&lookup_buf);
+    try host_name.lookup(io, &lookup_queue, .{ .port = port });
+
+    // A single deadline spans every resolved address. DNS can return up to 32
+    // records, so giving each attempt a full timeout_ms would let a hostile
+    // relay stretch the total connect wait to 32x timeout_ms and outlast the
+    // shutdown grace. Each attempt gets only the remaining budget; once it is
+    // exhausted we stop and report the last error.
+    const start_ns = Io.Timestamp.now(io, .awake).nanoseconds;
+    var last_err: error{ ConnectFailed, ConnectTimeout, UnknownHostName } = error.UnknownHostName;
+    while (lookup_queue.getOneUncancelable(io)) |res| switch (res) {
+        .address => |addr| {
+            const elapsed = @divTrunc(Io.Timestamp.now(io, .awake).nanoseconds - start_ns, std.time.ns_per_ms);
+            if (elapsed >= timeout_ms) return error.ConnectTimeout;
+            const remaining: u32 = if (elapsed <= 0) timeout_ms else timeout_ms - @as(u32, @intCast(elapsed));
+            return connectAddrTimeout(addr, remaining) catch |err| {
+                last_err = err;
+                continue;
+            };
+        },
+        .canonical_name => continue,
+    } else |err| switch (err) {
+        error.Closed => {},
+    }
+    return last_err;
+}
+
+fn connectAddrTimeout(addr: Io.net.IpAddress, timeout_ms: u32) error{ ConnectFailed, ConnectTimeout }!Io.net.Stream {
+    const address: posix.Address = switch (addr) {
+        .ip4 => |a| .{ .in = .{
+            .port = std.mem.nativeToBig(u16, a.port),
+            .addr = @bitCast(a.bytes),
+        } },
+        .ip6 => |a| .{ .in6 = .{
+            .port = std.mem.nativeToBig(u16, a.port),
+            .flowinfo = 0,
+            .addr = a.bytes,
+            .scope_id = 0,
+        } },
+    };
+
+    const sock_type = posix.SOCK.STREAM | posix.NONBLOCK | posix.CLOEXEC;
+    const fd = posix.socket(@intCast(address.any.family), sock_type, 0) catch return error.ConnectFailed;
+    errdefer posix.close(fd);
+
+    if (posix.connect(fd, &address.any, address.getOsSockLen())) |_| {
+        // Connected without blocking.
+    } else |err| switch (err) {
+        error.WouldBlock => {
+            var pfd = [_]std.posix.pollfd{.{ .fd = fd, .events = std.posix.POLL.OUT, .revents = 0 }};
+            // poll()'s timeout is a signed c_int; a misconfigured timeout larger
+            // than INT_MAX would panic on the cast, so clamp instead.
+            const poll_ms: i32 = @intCast(@min(timeout_ms, @as(u32, std.math.maxInt(i32))));
+            const ready = std.posix.poll(&pfd, poll_ms) catch return error.ConnectFailed;
+            if (ready == 0) return error.ConnectTimeout;
+            // poll() readiness does not imply success: an async connect failure
+            // is reported via SO_ERROR and need not set POLL.ERR/HUP, so this is
+            // the authoritative check. The specific errno (ETIMEDOUT,
+            // ECONNREFUSED, ...) is collapsed into ConnectFailed rather than
+            // misreported as one particular cause.
+            var so_err: i32 = 0;
+            var so_len: posix.socklen_t = @sizeOf(i32);
+            switch (std.posix.errno(posix.system.getsockopt(fd, posix.SOL.SOCKET, posix.SO.ERROR, @ptrCast(&so_err), &so_len))) {
+                .SUCCESS => {},
+                else => return error.ConnectFailed,
+            }
+            if (so_err != 0) return error.ConnectFailed;
+        },
+        else => return error.ConnectFailed,
+    }
+
+    // The handshake and read/write paths expect a blocking socket.
+    const nonblock: usize = @as(u32, @bitCast(std.posix.O{ .NONBLOCK = true }));
+    const flags = posix.fcntl(fd, posix.F.GETFL, 0) catch return error.ConnectFailed;
+    _ = posix.fcntl(fd, posix.F.SETFL, flags & ~nonblock) catch return error.ConnectFailed;
+
+    return .{ .socket = .{ .handle = fd, .address = addr } };
+}
+
+// Bounds the TLS handshake: a thread waits up to `timeout_ms` on a wake pipe
+// and, if the handshake has not finished by then, shuts the socket down so the
+// blocking handshake read/write fails instead of hanging. `disarm` wakes the
+// thread and joins it before the socket may be closed, so it never touches a
+// reused fd, and reports whether the shutdown fired: a handshake that completes
+// on the deadline edge otherwise yields a valid TLS client on a dead socket.
+//
+// Posix only. Zig 0.16 has no portable timed wait (std.Thread.ResetEvent is
+// gone, Io.Condition has no timedWait), and WSAPoll cannot wait on a pipe, so
+// on Windows the handshake is left unbounded rather than reimplemented against
+// raw kernel32 event handles. The guard must outlive its thread, so it is armed
+// in place rather than returned by value.
+const HandshakeGuard = struct {
+    wake_r: posix.fd_t,
+    wake_w: posix.fd_t,
+    fired: std.atomic.Value(bool),
+    thread: std.Thread,
+
+    fn arm(self: *HandshakeGuard, fd: posix.socket_t, timeout_ms: u32) !void {
+        const fds = try posix.pipe2(.{ .CLOEXEC = true });
+        errdefer {
+            posix.close(fds[0]);
+            posix.close(fds[1]);
+        }
+        self.* = .{
+            .wake_r = fds[0],
+            .wake_w = fds[1],
+            .fired = .init(false),
+            .thread = undefined,
+        };
+        self.thread = try std.Thread.spawn(.{}, watch, .{ self, fd, timeout_ms });
+    }
+
+    fn watch(self: *HandshakeGuard, fd: posix.socket_t, timeout_ms: u32) void {
+        var pfd = [_]std.posix.pollfd{.{ .fd = self.wake_r, .events = std.posix.POLL.IN, .revents = 0 }};
+        const poll_ms: i32 = @intCast(@min(timeout_ms, @as(u32, std.math.maxInt(i32))));
+        const ready = std.posix.poll(&pfd, poll_ms) catch return;
+        if (ready == 0) {
+            self.fired.store(true, .release);
+            posix.shutdown(fd, .both) catch {};
+        }
+    }
+
+    fn disarm(self: *HandshakeGuard) bool {
+        _ = posix.write(self.wake_w, "x") catch {};
+        self.thread.join();
+        posix.close(self.wake_r);
+        posix.close(self.wake_w);
+        return self.fired.load(.acquire);
+    }
+};
+
 pub const Client = struct {
     io: Io,
     stream: Stream,
@@ -65,6 +221,19 @@ pub const Client = struct {
         mask_fn: *const fn (Io) [4]u8 = generateMask,
         buffer_provider: ?*buffer.Provider = null,
         compression: ?CompressionOpts = null,
+        // Upper bound (ms) applied independently to the TCP connect and the TLS
+        // handshake, so a blackholed or stalling relay cannot hang init() (and
+        // thus a clean shutdown) indefinitely. The real bound on init() is
+        // DNS + connect + handshake: connect and handshake are each bounded by
+        // this value (a single deadline spans all resolved addresses on the
+        // connect side), so the two together are ~2x this value. 0 disables the
+        // bound entirely, matching readTimeout(0).
+        //
+        // Known residuals outside this bound: DNS resolution is never bounded
+        // (the Threaded Io cannot cancel host_name.lookup), and on Windows
+        // neither the connect nor the handshake is bounded — see connectTimeout
+        // and HandshakeGuard for why. Posix bounds both.
+        connect_timeout_ms: u32 = 10000,
     };
 
     pub const HandshakeOpts = struct {
@@ -85,12 +254,37 @@ pub const Client = struct {
             return error.InvalidConfiguraion;
         }
 
-        const host_name = try Io.net.HostName.init(config.host);
-        const net_stream = try host_name.connect(io, config.port, .{ .mode = .stream });
+        const net_stream = try connectTimeout(io, config.host, config.port, config.connect_timeout_ms);
+        // Own the connected socket for the rest of init: on any later failure
+        // (TLS handshake, buffer-provider create, reader_buf alloc) this closes
+        // the fd so it can't leak on either the TLS or non-TLS path. On success
+        // no errdefer fires and the fd is moved into the returned Client.
+        errdefer net_stream.close(io);
 
         var tls_client: ?*TLSClient = null;
         if (config.tls) {
-            tls_client = try TLSClient.init(io, allocator, net_stream, &config);
+            if (comptime @import("builtin").os.tag == .windows) {
+                tls_client = try TLSClient.init(io, allocator, net_stream, &config);
+            } else if (config.connect_timeout_ms == 0) {
+                tls_client = try TLSClient.init(io, allocator, net_stream, &config);
+            } else {
+                // The TLS handshake reads/writes on a blocking socket, so it
+                // cannot be time-bounded from here (a socket receive timeout
+                // surfaces as EAGAIN, which std.crypto.tls treats as a bug). A
+                // watchdog that shuts the socket down forces those blocking
+                // operations to fail instead of hanging.
+                var guard: HandshakeGuard = undefined;
+                try guard.arm(net_stream.socket.handle, config.connect_timeout_ms);
+                const result = TLSClient.init(io, allocator, net_stream, &config);
+                if (guard.disarm()) {
+                    // The watchdog shut the socket down. If the handshake won
+                    // the race anyway, its client is backed by a dead socket, so
+                    // report the timeout instead of handing it back.
+                    if (result) |tc| tc.deinit() else |_| {}
+                    return error.HandshakeTimeout;
+                }
+                tls_client = try result;
+            }
         }
         const stream = Stream.init(io, net_stream, tls_client);
 

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -1191,6 +1191,24 @@ test "Client: handshake" {
     }
 }
 
+test "connectTimeout: refused connect is not reported as a timeout" {
+    if (comptime @import("builtin").os.tag == .windows) return error.SkipZigTest;
+
+    // Nothing listens on loopback port 1, so connect() is refused immediately.
+    // The refusal arrives via SO_ERROR after poll() reports the socket writable,
+    // and must be reported as ConnectFailed, not ConnectTimeout.
+    try t.expectError(error.ConnectFailed, connectTimeout(t.io, "127.0.0.1", 1, 1000));
+
+    // 0 disables the bound (matching readTimeout(0)) rather than expiring
+    // instantly. It must still fail here, but never with ConnectTimeout.
+    if (connectTimeout(t.io, "127.0.0.1", 1, 0)) |stream| {
+        stream.close(t.io);
+        return error.TestUnexpectedResult;
+    } else |err| {
+        try t.expectEqual(false, err == error.ConnectTimeout);
+    }
+}
+
 test "Client: write/read" {
     var client = try Client.init(t.io, t.allocator, .{
         .port = 9292,

--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -40,36 +40,25 @@ fn ReadLoopHandler(comptime T: type) type {
 // connect is driven manually: a non-blocking connect gated by poll(). The
 // returned stream's socket is left in blocking mode for the handshake and read
 // paths.
-//
-// `timeout_ms == 0` disables the bound, matching `readTimeout(0)`. Windows has
-// no usable poll()-gated connect — WSAPoll cannot report a failed non-blocking
-// connect, and std.posix.pollfd does not exist there — so it falls back to the
-// unbounded std connect.
 fn connectTimeout(io: Io, host: []const u8, port: u16, timeout_ms: u32) !Io.net.Stream {
     const host_name = try Io.net.HostName.init(host);
 
-    if (comptime @import("builtin").os.tag == .windows) {
+    if ((comptime @import("builtin").os.tag == .windows) or timeout_ms == 0) {
         return host_name.connect(io, port, .{ .mode = .stream });
-    } else {
-        if (timeout_ms == 0) {
-            return host_name.connect(io, port, .{ .mode = .stream });
-        }
-        return connectTimeoutPosix(io, host_name, port, timeout_ms);
     }
-}
 
-fn connectTimeoutPosix(io: Io, host_name: Io.net.HostName, port: u16, timeout_ms: u32) !Io.net.Stream {
     var lookup_buf: [32]Io.net.HostName.LookupResult = undefined;
     var lookup_queue = Io.Queue(Io.net.HostName.LookupResult).init(&lookup_buf);
-    try host_name.lookup(io, &lookup_queue, .{ .port = port });
+    var lookup_future = io.async(Io.net.HostName.lookup, .{ host_name, io, &lookup_queue, .{ .port = port } });
+    defer lookup_future.cancel(io) catch {};
 
-    // A single deadline spans every resolved address. DNS can return up to 32
+    // A single deadline spans every resolved address. DNS can return many
     // records, so giving each attempt a full timeout_ms would let a hostile
-    // relay stretch the total connect wait to 32x timeout_ms and outlast the
+    // relay stretch the total connect wait to N x timeout_ms and outlast the
     // shutdown grace. Each attempt gets only the remaining budget; once it is
     // exhausted we stop and report the last error.
     const start_ns = Io.Timestamp.now(io, .awake).nanoseconds;
-    var last_err: error{ ConnectFailed, ConnectTimeout, UnknownHostName } = error.UnknownHostName;
+    var last_err: ?ConnectAddrError = null;
     while (lookup_queue.getOneUncancelable(io)) |res| switch (res) {
         .address => |addr| {
             const elapsed = @divTrunc(Io.Timestamp.now(io, .awake).nanoseconds - start_ns, std.time.ns_per_ms);
@@ -84,10 +73,17 @@ fn connectTimeoutPosix(io: Io, host_name: Io.net.HostName, port: u16, timeout_ms
     } else |err| switch (err) {
         error.Closed => {},
     }
-    return last_err;
+    if (last_err) |err| {
+        return err;
+    }
+    // No addresses at all: surface the resolver's error if it had one.
+    try lookup_future.await(io);
+    return error.UnknownHostName;
 }
 
-fn connectAddrTimeout(addr: Io.net.IpAddress, timeout_ms: u32) error{ ConnectFailed, ConnectTimeout }!Io.net.Stream {
+const ConnectAddrError = error{ ConnectFailed, ConnectTimeout, ConnectionRefused, NetworkUnreachable };
+
+fn connectAddrTimeout(addr: Io.net.IpAddress, timeout_ms: u32) ConnectAddrError!Io.net.Stream {
     const address: posix.Address = switch (addr) {
         .ip4 => |a| .{ .in = .{
             .port = std.mem.nativeToBig(u16, a.port),
@@ -95,9 +91,11 @@ fn connectAddrTimeout(addr: Io.net.IpAddress, timeout_ms: u32) error{ ConnectFai
         } },
         .ip6 => |a| .{ .in6 = .{
             .port = std.mem.nativeToBig(u16, a.port),
-            .flowinfo = 0,
+            .flowinfo = a.flow,
             .addr = a.bytes,
-            .scope_id = 0,
+            // Required for link-local (fe80::) addresses to pick the right
+            // interface; Interface.none has index 0.
+            .scope_id = a.interface.index,
         } },
     };
 
@@ -117,17 +115,23 @@ fn connectAddrTimeout(addr: Io.net.IpAddress, timeout_ms: u32) error{ ConnectFai
             if (ready == 0) return error.ConnectTimeout;
             // poll() readiness does not imply success: an async connect failure
             // is reported via SO_ERROR and need not set POLL.ERR/HUP, so this is
-            // the authoritative check. The specific errno (ETIMEDOUT,
-            // ECONNREFUSED, ...) is collapsed into ConnectFailed rather than
-            // misreported as one particular cause.
+            // the authoritative check.
             var so_err: i32 = 0;
             var so_len: posix.socklen_t = @sizeOf(i32);
             switch (std.posix.errno(posix.system.getsockopt(fd, posix.SOL.SOCKET, posix.SO.ERROR, @ptrCast(&so_err), &so_len))) {
                 .SUCCESS => {},
                 else => return error.ConnectFailed,
             }
-            if (so_err != 0) return error.ConnectFailed;
+            if (so_err != 0) return switch (@as(std.posix.E, @enumFromInt(so_err))) {
+                .CONNREFUSED => error.ConnectionRefused,
+                .TIMEDOUT => error.ConnectTimeout,
+                .HOSTUNREACH, .NETUNREACH => error.NetworkUnreachable,
+                else => error.ConnectFailed,
+            };
         },
+        error.ConnectionRefused => return error.ConnectionRefused,
+        error.NetworkUnreachable => return error.NetworkUnreachable,
+        error.ConnectionTimedOut => return error.ConnectTimeout,
         else => return error.ConnectFailed,
     }
 
@@ -143,53 +147,71 @@ fn connectAddrTimeout(addr: Io.net.IpAddress, timeout_ms: u32) error{ ConnectFai
 // and, if the handshake has not finished by then, shuts the socket down so the
 // blocking handshake read/write fails instead of hanging. `disarm` wakes the
 // thread and joins it before the socket may be closed, so it never touches a
-// reused fd, and reports whether the shutdown fired: a handshake that completes
-// on the deadline edge otherwise yields a valid TLS client on a dead socket.
-//
-// Posix only. Zig 0.16 has no portable timed wait (std.Thread.ResetEvent is
-// gone, Io.Condition has no timedWait), and WSAPoll cannot wait on a pipe, so
-// on Windows the handshake is left unbounded rather than reimplemented against
-// raw kernel32 event handles. The guard must outlive its thread, so it is armed
-// in place rather than returned by value.
+// reused fd.
 const HandshakeGuard = struct {
     wake_r: posix.fd_t,
     wake_w: posix.fd_t,
-    fired: std.atomic.Value(bool),
     thread: std.Thread,
 
-    fn arm(self: *HandshakeGuard, fd: posix.socket_t, timeout_ms: u32) !void {
+    fn arm(fd: posix.socket_t, timeout_ms: u32, timed_out: *std.atomic.Value(bool)) !HandshakeGuard {
         const fds = try posix.pipe2(.{ .CLOEXEC = true });
         errdefer {
             posix.close(fds[0]);
             posix.close(fds[1]);
         }
-        self.* = .{
-            .wake_r = fds[0],
-            .wake_w = fds[1],
-            .fired = .init(false),
-            .thread = undefined,
-        };
-        self.thread = try std.Thread.spawn(.{}, watch, .{ self, fd, timeout_ms });
+        const thread = try std.Thread.spawn(.{}, watch, .{ fd, timeout_ms, fds[0], timed_out });
+        return .{ .wake_r = fds[0], .wake_w = fds[1], .thread = thread };
     }
 
-    fn watch(self: *HandshakeGuard, fd: posix.socket_t, timeout_ms: u32) void {
-        var pfd = [_]std.posix.pollfd{.{ .fd = self.wake_r, .events = std.posix.POLL.IN, .revents = 0 }};
+    fn watch(fd: posix.socket_t, timeout_ms: u32, wake_r: posix.fd_t, timed_out: *std.atomic.Value(bool)) void {
+        var pfd = [_]std.posix.pollfd{.{ .fd = wake_r, .events = std.posix.POLL.IN, .revents = 0 }};
         const poll_ms: i32 = @intCast(@min(timeout_ms, @as(u32, std.math.maxInt(i32))));
         const ready = std.posix.poll(&pfd, poll_ms) catch return;
         if (ready == 0) {
-            self.fired.store(true, .release);
+            timed_out.store(true, .release);
             posix.shutdown(fd, .both) catch {};
         }
     }
 
-    fn disarm(self: *HandshakeGuard) bool {
+    fn disarm(self: *HandshakeGuard) void {
         _ = posix.write(self.wake_w, "x") catch {};
         self.thread.join();
         posix.close(self.wake_r);
         posix.close(self.wake_w);
-        return self.fired.load(.acquire);
     }
 };
+
+// The TLS handshake reads/writes on a blocking socket, so it cannot be
+// time-bounded from the caller (a socket receive timeout surfaces as EAGAIN,
+// which std.crypto.tls treats as a bug). A watchdog that shuts the socket down
+// forces those blocking operations to fail instead of hanging; the timed_out
+// flag then reports that failure as a timeout rather than as the read error
+// the shutdown provoked.
+fn initTLSClientTimeout(io: Io, allocator: Allocator, net_stream: Io.net.Stream, config: *const Client.Config) !*TLSClient {
+    if (comptime @import("builtin").os.tag == .windows) {
+        // HandshakeGuard is POSIX-only (pipe + poll); see connectTimeout.
+        return TLSClient.init(io, allocator, net_stream, config);
+    }
+    if (config.connect_timeout_ms == 0) {
+        return TLSClient.init(io, allocator, net_stream, config);
+    }
+
+    var timed_out: std.atomic.Value(bool) = .init(false);
+    var guard = try HandshakeGuard.arm(net_stream.socket.handle, config.connect_timeout_ms, &timed_out);
+    const tls_client = TLSClient.init(io, allocator, net_stream, config) catch |err| {
+        guard.disarm();
+        if (timed_out.load(.acquire)) return error.TlsHandshakeTimeout;
+        return err;
+    };
+    guard.disarm();
+    if (timed_out.load(.acquire)) {
+        // The watchdog fired just as the handshake completed: the socket has
+        // been shut down, so the "successful" client is unusable.
+        tls_client.deinit();
+        return error.TlsHandshakeTimeout;
+    }
+    return tls_client;
+}
 
 pub const Client = struct {
     io: Io,
@@ -226,13 +248,12 @@ pub const Client = struct {
         // thus a clean shutdown) indefinitely. The real bound on init() is
         // DNS + connect + handshake: connect and handshake are each bounded by
         // this value (a single deadline spans all resolved addresses on the
-        // connect side), so the two together are ~2x this value. 0 disables the
-        // bound entirely, matching readTimeout(0).
-        //
-        // Known residuals outside this bound: DNS resolution is never bounded
-        // (the Threaded Io cannot cancel host_name.lookup), and on Windows
-        // neither the connect nor the handshake is bounded — see connectTimeout
-        // and HandshakeGuard for why. Posix bounds both.
+        // connect side), so the two together are ~2x this value. DNS resolution
+        // is NOT bounded — the Threaded Io cannot cancel host_name.lookup — so a
+        // hung resolver is a known residual outside this bound.
+        // 0 disables the timeout (consistent with readTimeout). On Windows the
+        // timeout is currently not enforced: the enforcement mechanisms are
+        // POSIX-only and the std Io api cannot yet bound a connect.
         connect_timeout_ms: u32 = 10000,
     };
 
@@ -263,28 +284,7 @@ pub const Client = struct {
 
         var tls_client: ?*TLSClient = null;
         if (config.tls) {
-            if (comptime @import("builtin").os.tag == .windows) {
-                tls_client = try TLSClient.init(io, allocator, net_stream, &config);
-            } else if (config.connect_timeout_ms == 0) {
-                tls_client = try TLSClient.init(io, allocator, net_stream, &config);
-            } else {
-                // The TLS handshake reads/writes on a blocking socket, so it
-                // cannot be time-bounded from here (a socket receive timeout
-                // surfaces as EAGAIN, which std.crypto.tls treats as a bug). A
-                // watchdog that shuts the socket down forces those blocking
-                // operations to fail instead of hanging.
-                var guard: HandshakeGuard = undefined;
-                try guard.arm(net_stream.socket.handle, config.connect_timeout_ms);
-                const result = TLSClient.init(io, allocator, net_stream, &config);
-                if (guard.disarm()) {
-                    // The watchdog shut the socket down. If the handshake won
-                    // the race anyway, its client is backed by a dead socket, so
-                    // report the timeout instead of handing it back.
-                    if (result) |tc| tc.deinit() else |_| {}
-                    return error.HandshakeTimeout;
-                }
-                tls_client = try result;
-            }
+            tls_client = try initTLSClientTimeout(io, allocator, net_stream, &config);
         }
         const stream = Stream.init(io, net_stream, tls_client);
 
@@ -643,7 +643,7 @@ pub const Stream = struct {
                 // >0 only once that buffer holds plaintext. A single stream()
                 // will often (typically?) returns 0 without yielding a plaintext
                 // message. We have to loop until we get a visible message..
-                if (tls_client.client.reader.bufferedLen() == 0 and !hasBufferedTlsRecord(tls_client.client.input) and !try self.pollReadable()) {
+                if (tls_client.client.reader.bufferedLen() == 0 and !try self.pollReadable()) {
                     return error.WouldBlock;
                 }
                 const n = try tls_client.client.reader.stream(&w, .limited(buf.len));
@@ -666,22 +666,6 @@ pub const Stream = struct {
             return error.WouldBlock;
         }
         return posix.read(self.stream.socket.handle, buf);
-    }
-
-    // Ciphertext already drained off the socket sits in
-    // tls_client.client.input, invisible to poll(). If a complete
-    // record is buffered there, stream() can decrypt it without
-    // touching the socket, so we must not poll (the socket may
-    // legitimately be empty). But a *partial* record makes stream()
-    // do a blocking socket read to complete it, so in that case we
-    // still poll to honor the read timeout.
-    fn hasBufferedTlsRecord(input: *std.Io.Reader) bool {
-        const buffered = input.buffered();
-        if (buffered.len < std.crypto.tls.record_header_len) {
-            return false;
-        }
-        const record_len = std.mem.readInt(u16, buffered[3..5], .big);
-        return buffered.len >= std.crypto.tls.record_header_len + record_len;
     }
 
     fn pollReadable(self: *Stream) !bool {
@@ -1188,24 +1172,6 @@ test "Client: handshake" {
         defer client.deinit();
         try client.handshake("/", .{});
         try t.expectEqual(50, client._reader.pos);
-    }
-}
-
-test "connectTimeout: refused connect is not reported as a timeout" {
-    if (comptime @import("builtin").os.tag == .windows) return error.SkipZigTest;
-
-    // Nothing listens on loopback port 1, so connect() is refused immediately.
-    // The refusal arrives via SO_ERROR after poll() reports the socket writable,
-    // and must be reported as ConnectFailed, not ConnectTimeout.
-    try t.expectError(error.ConnectFailed, connectTimeout(t.io, "127.0.0.1", 1, 1000));
-
-    // 0 disables the bound (matching readTimeout(0)) rather than expiring
-    // instantly. It must still fail here, but never with ConnectTimeout.
-    if (connectTimeout(t.io, "127.0.0.1", 1, 0)) |stream| {
-        stream.close(t.io);
-        return error.TestUnexpectedResult;
-    } else |err| {
-        try t.expectEqual(false, err == error.ConnectTimeout);
     }
 }
 


### PR DESCRIPTION
## Problem

`Client.init` does an unbounded TCP connect and TLS handshake. A peer that drops the SYN (the kernel connect can take minutes) or completes TCP then stalls the TLS handshake hangs `init()`, and there is no way for the caller to abort it, which makes a clean, timely shutdown impossible when a configured server is unreachable or hostile.

## Change

Adds a `connect_timeout_ms` config field (default 10s), applied independently to the connect and handshake phases:

- **TCP connect**: a manual non-blocking connect gated by `poll()`, since the Threaded `Io` panics when asked for a connect timeout. A single monotonic-clock deadline spans all resolved addresses, so a multi-record DNS answer cannot multiply the total wait. `SO_ERROR` is checked after `poll()` to catch asynchronous connect failures, since readiness alone does not imply success.
- **TLS handshake**: bounded by a watchdog thread that shuts the socket down after the timeout, forcing the blocking handshake read/write to fail. A socket receive timeout cannot be used here because it surfaces as `EAGAIN`, which `std.crypto.tls` treats as a programmer bug.

`connect_timeout_ms = 0` disables the bound, matching the existing `readTimeout(0)` convention.

If the watchdog fires at the same moment the handshake completes, the handshake would otherwise return a valid TLS client backed by a socket that was just shut down. `disarm()` reports whether the shutdown fired, and `init()` tears the client down and returns `error.HandshakeTimeout` rather than handing back a connection whose first read fails.

## Platform support

Bounded on posix. **Not bounded on Windows**, where `init()` behaves exactly as it does today:

- The connect falls back to the unbounded `HostName.connect`. `std.posix.pollfd` does not exist on Windows, and `WSAPoll` cannot report a failed non-blocking connect via `POLLOUT`/`POLLERR`, so the poll-gated connect has no direct equivalent.
- The handshake watchdog is posix-only. Zig 0.16 has no portable timed wait (`std.Thread.ResetEvent` was removed, `Io.Condition` has no `timedWait`, there is no futex), and `WSAPoll` cannot wait on a pipe. Reimplementing the wake against raw `kernel32` event handles was judged not worth the untestable surface for this change.

DNS resolution is not bounded on any platform. `Io.net.HostName.lookup` is uncancellable and `std.Io.Threaded` cannot cancel it. In practice the libc resolver self-bounds via `resolv.conf` (timeout x attempts x nameservers), but that is not guaranteed. Bounding DNS robustly needs a cancellable resolver API the standard library does not currently provide.

Both residuals are documented on the `connect_timeout_ms` field.

## Tests

Adds a deterministic test that a refused loopback connect is reported as `ConnectFailed` (via the `SO_ERROR` check) and never as `ConnectTimeout`, and that `connect_timeout_ms = 0` does not expire instantly.

## Verification

- `zig build test` on Zig 0.16: 32/32 pass on Linux.
- Cross-compiles clean for `x86_64-windows` and `aarch64-macos`.

Note that `zig build` alone does not compile this package, since the module is not an artifact. Only `zig build test` exercises the compiler, which is what the Windows and macOS checks above use.
