### PR TITLE
client: clamp read timeout to INT_MAX before passing to poll

### DIFF
--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -502,9 +502,14 @@ pub const Stream = struct {
             .events = std.posix.POLL.IN,
             .revents = 0,
         }};
+        // poll()'s timeout is a signed c_int. Clamp rather than cast: a timeout
+        // above INT_MAX panics in safe builds, and in ReleaseFast wraps to a
+        // negative value, which makes poll() block forever and silently defeats
+        // the timeout it is implementing.
+        const poll_ms: i32 = @intCast(@min(self.read_timeout_ms, @as(u32, std.math.maxInt(i32))));
         // A poll failure is a real read failure, not "no data": surface it
         // (mapped into this read path's error set) rather than swallowing it.
-        const ready = std.posix.poll(&pfd, @intCast(self.read_timeout_ms)) catch return error.ReadFailed;
+        const ready = std.posix.poll(&pfd, poll_ms) catch return error.ReadFailed;
         return ready != 0;
     }
 


### PR DESCRIPTION
## Problem

`Stream.pollReadable` casts `read_timeout_ms` (a `u32`) directly into `poll()`'s signed `c_int` timeout:

```zig
const ready = std.posix.poll(&pfd, @intCast(self.read_timeout_ms)) catch return error.ReadFailed;
```

For a `readTimeout(ms)` above `INT_MAX` (about 24.8 days), that `@intCast` panics in safe builds. In `ReleaseFast` it wraps to a negative value, which `poll()` interprets as "wait forever", silently defeating the timeout it is meant to implement.

The two other `poll()` call sites in this file already clamp with `@min(timeout_ms, maxInt(i32))`. This makes the third consistent.

## Change

Clamp instead of casting. The value is caller-supplied rather than attacker-supplied, so severity is low, but the failure mode in `ReleaseFast` is an unbounded read rather than a crash, which is the worse of the two outcomes.

No behavior change for any timeout at or below `INT_MAX` ms.

## Verification

`zig build test` passes on Zig 0.16 (31/31), and the package cross-compiles clean for `x86_64-windows`.

## Related

Split out of a review of #108. Both this and #109 are follow-ups to the `poll()`-based read timeout introduced in #103.

#109 (`readTimeout` is a no-op on Windows) touches the same `pollReadable` function but is not fixable in one line, since it needs a decision about where a Windows read deadline should live. This PR is deliberately independent of it: it is branched off `master` rather than #108, and can merge in any order.
