### PR TITLE
fix: TLS Stream.read() ignores buffered-but-undecrypted bytes

### DIFF
--- a/src/client/client.zig
+++ b/src/client/client.zig
@@ -643,7 +643,7 @@ pub const Stream = struct {
                 // >0 only once that buffer holds plaintext. A single stream()
                 // will often (typically?) returns 0 without yielding a plaintext
                 // message. We have to loop until we get a visible message..
-                if (tls_client.client.reader.bufferedLen() == 0 and !try self.pollReadable()) {
+                if (tls_client.client.reader.bufferedLen() == 0 and tls_client.stream_reader.interface.bufferedLen() == 0 and !try self.pollReadable()) {
                     return error.WouldBlock;
                 }
                 const n = try tls_client.client.reader.stream(&w, .limited(buf.len));


### PR DESCRIPTION
# Explanation:
Stream.read() (TLS) only checked tls_client.client.reader's decrypted buffer and the raw fd's poll() readiness before returning WouldBlock. This misses the case where ciphertext has already been read off the socket into stream_reader's buffer but not yet decrypted.

In that case kernel's poll() reports the socket as empty, since the bytes are already sitting in userspace, which makes read() incorrectly return WouldBlock even though the data is available locally.

Reproduced against Discord's gateway with Zig 0.16.0. TLS Handshake is completed successfully, HTTP 101 response is sent by the server, but the client hangs until connect_timeout_ms expires with error.Timeout.

# Images showing debug logs exposing the error:
<img width="959" height="159" alt="image" src="https://github.com/user-attachments/assets/fd9f33de-c104-41ce-93d3-774410d42886" />

## With patch:
<img width="1254" height="225" alt="image" src="https://github.com/user-attachments/assets/cced5150-f70f-423e-882c-e023c7006f48" />
<img width="802" height="181" alt="image" src="https://github.com/user-attachments/assets/22b6dcbe-6a41-4b93-b47e-c3fce8a88371" />

## Without patch:
<img width="1122" height="268" alt="image" src="https://github.com/user-attachments/assets/b74a5357-df3a-4f8e-9ff9-0791c18b7184" />