### PR TITLE
Fix passing unowned pointer to fallback in resize() of FallbackAllocator

### DIFF
--- a/src/server/fallback_allocator.zig
+++ b/src/server/fallback_allocator.zig
@@ -32,9 +32,7 @@ pub const FallbackAllocator = struct {
     fn resize(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
         const self: *FallbackAllocator = @ptrCast(@alignCast(ctx));
         if (self.fba.ownsPtr(buf.ptr)) {
-            if (self.fixed.rawResize(buf, alignment, new_len, ra)) {
-                return true;
-            }
+            return self.fixed.rawResize(buf, alignment, new_len, ra);
         }
         return self.fallback.rawResize(buf, alignment, new_len, ra);
     }


### PR DESCRIPTION
when resizing a pointer with the fixed buffer allocator fails, return false and let upstream code make a fresh allocation, instead of falling through and passing an unowned pointer for resizing to the fallback allocator.

fixes #112.